### PR TITLE
Create com.dremio.telemetry.api.config.ConfigModule

### DIFF
--- a/src/main/resources/META-INF/services/com.dremio.telemetry.api.config.ConfigModule
+++ b/src/main/resources/META-INF/services/com.dremio.telemetry.api.config.ConfigModule
@@ -1,0 +1,1 @@
+com.dremio.metrics.prometheus.PrometheusConfigurator$Module


### PR DESCRIPTION
Fix for Dremio not recognising Prometheus as a metrics type.